### PR TITLE
Sleep between codeforces getCfUserInfo requests

### DIFF
--- a/src/api/cfApi.js
+++ b/src/api/cfApi.js
@@ -17,8 +17,11 @@ export async function getCfContest() {
       });
   });
 }
-
+const sleep = (milliseconds) => {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+};
 export async function getCfUserInfo(username) {
+  await sleep(300);
   const url = `https://codeforces.com/api/user.status?handle=${username}`;
   return new Promise((resolve, reject) => {
     Axios.get(url)


### PR DESCRIPTION
Add 300ms delay between `getCfUserInfo` to avoid `503 Service Temporarily Unavailable` when adding a lot of cf handles (+5) where codeforces API may be requested at most 1 time per two seconds

Reference: https://codeforces.com/apiHelp#:~:text=API%20may%20be%20requested%20at%20most%201%20time%20per%20two%20seconds

Note: 
It will also fail because 300ms is too small, but I think its the average to use around 10 handles 

![image](https://user-images.githubusercontent.com/42287052/167452995-327ee1b9-295b-458f-b2b0-eacaf066ef8d.png)
